### PR TITLE
Rename appAttestation to deviceIntegrity

### DIFF
--- a/Authsignal.podspec
+++ b/Authsignal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Authsignal'
-  s.version          = '2.4.0-alpha.2'
+  s.version          = '2.4.0-alpha.3'
   s.summary          = 'The Authsignal SDK for iOS'
 
   s.homepage         = 'https://github.com/authsignal/authsignal-ios'

--- a/Authsignal.podspec
+++ b/Authsignal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Authsignal'
-  s.version          = '2.4.0-alpha.3'
+  s.version          = '2.4.0-alpha.4'
   s.summary          = 'The Authsignal SDK for iOS'
 
   s.homepage         = 'https://github.com/authsignal/authsignal-ios'

--- a/Authsignal.podspec
+++ b/Authsignal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Authsignal'
-  s.version          = '2.4.0-alpha.1'
+  s.version          = '2.4.0-alpha.2'
   s.summary          = 'The Authsignal SDK for iOS'
 
   s.homepage         = 'https://github.com/authsignal/authsignal-ios'

--- a/Sources/Authsignal/API/InAppAPIClient.swift
+++ b/Sources/Authsignal/API/InAppAPIClient.swift
@@ -13,7 +13,7 @@ class InAppAPIClient: BaseAPIClient {
     token: String,
     publicKey: String,
     deviceName: String,
-    appAttestation: AppAttestation? = nil
+    deviceIntegrity: DeviceIntegrity? = nil
   ) async -> AuthsignalResponse<AddCredentialResponse>
   {
     let url = "\(baseURL)/client/user-authenticators/in-app"
@@ -22,7 +22,7 @@ class InAppAPIClient: BaseAPIClient {
       publicKey: publicKey,
       deviceName: deviceName,
       devicePlatform: "ios",
-      appAttestation: appAttestation
+      deviceIntegrity: deviceIntegrity
     )
 
     return await postRequest(url: url, body: body, token: token)

--- a/Sources/Authsignal/API/Models/App/AddCredentialRequest.swift
+++ b/Sources/Authsignal/API/Models/App/AddCredentialRequest.swift
@@ -14,7 +14,7 @@ public struct AddCredentialRequest: Codable {
     self.deviceName = deviceName
     self.devicePlatform = devicePlatform
     self.appAttestation = appAttestation.map {
-      AddCredentialAppAttestation(provider: "APP_ATTEST", token: $0.token, keyId: $0.keyId)
+      AddCredentialAppAttestation(provider: "APP_ATTEST", token: $0.attestationToken, keyId: $0.keyId)
     }
   }
 }

--- a/Sources/Authsignal/API/Models/App/AddCredentialRequest.swift
+++ b/Sources/Authsignal/API/Models/App/AddCredentialRequest.swift
@@ -2,7 +2,7 @@ public struct AddCredentialRequest: Codable {
   public let publicKey: String
   public let deviceName: String
   public let devicePlatform: String
-  public let appAttestation: AppAttestation?
+  let appAttestation: AddCredentialAppAttestation?
 
   public init(
     publicKey: String,
@@ -13,6 +13,14 @@ public struct AddCredentialRequest: Codable {
     self.publicKey = publicKey
     self.deviceName = deviceName
     self.devicePlatform = devicePlatform
-    self.appAttestation = appAttestation
+    self.appAttestation = appAttestation.map {
+      AddCredentialAppAttestation(provider: "APP_ATTEST", token: $0.token, keyId: $0.keyId)
+    }
   }
+}
+
+struct AddCredentialAppAttestation: Codable {
+  let provider: String
+  let token: String
+  let keyId: String?
 }

--- a/Sources/Authsignal/API/Models/App/AddCredentialRequest.swift
+++ b/Sources/Authsignal/API/Models/App/AddCredentialRequest.swift
@@ -2,24 +2,24 @@ public struct AddCredentialRequest: Codable {
   public let publicKey: String
   public let deviceName: String
   public let devicePlatform: String
-  let appAttestation: AddCredentialAppAttestation?
+  let deviceIntegrity: AddCredentialDeviceIntegrity?
 
   public init(
     publicKey: String,
     deviceName: String,
     devicePlatform: String,
-    appAttestation: AppAttestation? = nil
+    deviceIntegrity: DeviceIntegrity? = nil
   ) {
     self.publicKey = publicKey
     self.deviceName = deviceName
     self.devicePlatform = devicePlatform
-    self.appAttestation = appAttestation.map {
-      AddCredentialAppAttestation(provider: "APP_ATTEST", token: $0.attestationToken, keyId: $0.keyId)
+    self.deviceIntegrity = deviceIntegrity.map {
+      AddCredentialDeviceIntegrity(provider: "APP_ATTEST", token: $0.integrityToken, keyId: $0.keyId)
     }
   }
 }
 
-struct AddCredentialAppAttestation: Codable {
+struct AddCredentialDeviceIntegrity: Codable {
   let provider: String
   let token: String
   let keyId: String?

--- a/Sources/Authsignal/AuthsignalInApp.swift
+++ b/Sources/Authsignal/AuthsignalInApp.swift
@@ -46,7 +46,7 @@ public class AuthsignalInApp {
     keychainAccess: KeychainAccess = .whenUnlockedThisDeviceOnly,
     userPresenceRequired: Bool = false,
     username: String? = nil,
-    appAttestation: AppAttestation? = nil
+    appAttestation: Bool = false
   ) async -> AuthsignalResponse<AppCredential> {
     guard let userToken = token ?? cache.token else { return cache.handleTokenNotSetError() }
 
@@ -58,11 +58,15 @@ public class AuthsignalInApp {
       return AuthsignalResponse(errorCode: SdkErrorCodes.createKeyPairFailed)
     }
 
-    var resolvedAttestation = appAttestation
-    if appAttestation != nil {
+    var resolvedAttestation: AppAttestation? = nil
+    if appAttestation {
       if #available(iOS 14.0, *), DCAppAttestService.shared.isSupported {
         do {
-          let nonce = "\(tenantID):\(publicKey)"
+          guard let idempotencyKey = Self.extractIdempotencyKey(from: userToken) else {
+            return AuthsignalResponse(error: "Failed to extract idempotencyKey from token", errorCode: "invalid_token")
+          }
+
+          let nonce = idempotencyKey
           let nonceData = Data(nonce.utf8)
           let nonceHash = Data(SHA256.hash(data: nonceData))
 
@@ -73,10 +77,7 @@ public class AuthsignalInApp {
           resolvedAttestation = AppAttestation(attestationToken: attestationToken, keyId: keyId)
         } catch {
           Logger.error("App Attest failed: \(error.localizedDescription)")
-          resolvedAttestation = nil
         }
-      } else {
-        resolvedAttestation = nil
       }
     }
 
@@ -220,7 +221,19 @@ public class AuthsignalInApp {
 
   public func getAllPinUsernames() async -> AuthsignalResponse<[String]> {
     let usernames = pinManager.getAllUsernames()
-    
+
     return AuthsignalResponse(data: usernames)
+  }
+
+  private static func extractIdempotencyKey(from token: String) -> String? {
+    let parts = token.split(separator: ".")
+    guard parts.count >= 2 else { return nil }
+
+    let payload = String(parts[1]).base64URLUnescaped()
+    guard let data = Data(base64Encoded: payload) else { return nil }
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+    guard let other = json["other"] as? [String: Any] else { return nil }
+
+    return other["idempotencyKey"] as? String
   }
 }

--- a/Sources/Authsignal/AuthsignalInApp.swift
+++ b/Sources/Authsignal/AuthsignalInApp.swift
@@ -46,7 +46,7 @@ public class AuthsignalInApp {
     keychainAccess: KeychainAccess = .whenUnlockedThisDeviceOnly,
     userPresenceRequired: Bool = false,
     username: String? = nil,
-    appAttestation: Bool = false
+    deviceIntegrity: Bool = false
   ) async -> AuthsignalResponse<AppCredential> {
     guard let userToken = token ?? cache.token else { return cache.handleTokenNotSetError() }
 
@@ -58,8 +58,8 @@ public class AuthsignalInApp {
       return AuthsignalResponse(errorCode: SdkErrorCodes.createKeyPairFailed)
     }
 
-    var resolvedAttestation: AppAttestation? = nil
-    if appAttestation {
+    var resolvedIntegrity: DeviceIntegrity? = nil
+    if deviceIntegrity {
       if #available(iOS 14.0, *), DCAppAttestService.shared.isSupported {
         do {
           guard let idempotencyKey = Self.extractIdempotencyKey(from: userToken) else {
@@ -71,10 +71,10 @@ public class AuthsignalInApp {
           let nonceHash = Data(SHA256.hash(data: nonceData))
 
           let keyId = try await DCAppAttestService.shared.generateKey()
-          let attestationData = try await DCAppAttestService.shared.attestKey(keyId, clientDataHash: nonceHash)
-          let attestationToken = attestationData.base64EncodedString()
+          let integrityData = try await DCAppAttestService.shared.attestKey(keyId, clientDataHash: nonceHash)
+          let integrityToken = integrityData.base64EncodedString()
 
-          resolvedAttestation = AppAttestation(attestationToken: attestationToken, keyId: keyId)
+          resolvedIntegrity = DeviceIntegrity(integrityToken: integrityToken, keyId: keyId)
         } catch {
           Logger.error("App Attest failed: \(error.localizedDescription)")
         }
@@ -87,7 +87,7 @@ public class AuthsignalInApp {
       token: userToken,
       publicKey: publicKey,
       deviceName: deviceName,
-      appAttestation: resolvedAttestation
+      deviceIntegrity: resolvedIntegrity
     )
 
     guard let data = response.data else {

--- a/Sources/Authsignal/AuthsignalInApp.swift
+++ b/Sources/Authsignal/AuthsignalInApp.swift
@@ -1,14 +1,18 @@
 import Foundation
 import Security
 import UIKit
+import DeviceCheck
+import CryptoKit
 
 public class AuthsignalInApp {
   private let api: InAppAPIClient
   private let cache = TokenCache.shared
   private let keyManager = KeyManager(keySuffix: "in_app")
   private let pinManager = PinManager()
+  private let tenantID: String
 
   public init(tenantID: String, baseURL: String) {
+    self.tenantID = tenantID
     api = InAppAPIClient(tenantID: tenantID, baseURL: baseURL)
   }
 
@@ -45,7 +49,7 @@ public class AuthsignalInApp {
     appAttestation: AppAttestation? = nil
   ) async -> AuthsignalResponse<AppCredential> {
     guard let userToken = token ?? cache.token else { return cache.handleTokenNotSetError() }
-    
+
     guard let publicKey = keyManager.getOrCreatePublicKey(
       keychainAccess: keychainAccess,
       userPresenceRequired: userPresenceRequired,
@@ -54,19 +58,41 @@ public class AuthsignalInApp {
       return AuthsignalResponse(errorCode: SdkErrorCodes.createKeyPairFailed)
     }
 
+    var resolvedAttestation = appAttestation
+    if appAttestation != nil {
+      if #available(iOS 14.0, *), DCAppAttestService.shared.isSupported {
+        do {
+          let nonce = "\(tenantID):\(publicKey)"
+          let nonceData = Data(nonce.utf8)
+          let nonceHash = Data(SHA256.hash(data: nonceData))
+
+          let keyId = try await DCAppAttestService.shared.generateKey()
+          let attestationData = try await DCAppAttestService.shared.attestKey(keyId, clientDataHash: nonceHash)
+          let attestationToken = attestationData.base64EncodedString()
+
+          resolvedAttestation = AppAttestation(token: attestationToken, keyId: keyId)
+        } catch {
+          Logger.error("App Attest failed: \(error.localizedDescription)")
+          resolvedAttestation = nil
+        }
+      } else {
+        resolvedAttestation = nil
+      }
+    }
+
     let deviceName = await UIDevice.current.name
 
     let response = await api.addCredential(
       token: userToken,
       publicKey: publicKey,
       deviceName: deviceName,
-      appAttestation: appAttestation
+      appAttestation: resolvedAttestation
     )
-    
+
     guard let data = response.data else {
       return AuthsignalResponse(error: response.error, errorCode: response.errorCode)
     }
-    
+
     let credential = AppCredential(
       credentialId: data.userAuthenticatorId,
       createdAt: data.verifiedAt,

--- a/Sources/Authsignal/AuthsignalInApp.swift
+++ b/Sources/Authsignal/AuthsignalInApp.swift
@@ -70,7 +70,7 @@ public class AuthsignalInApp {
           let attestationData = try await DCAppAttestService.shared.attestKey(keyId, clientDataHash: nonceHash)
           let attestationToken = attestationData.base64EncodedString()
 
-          resolvedAttestation = AppAttestation(token: attestationToken, keyId: keyId)
+          resolvedAttestation = AppAttestation(attestationToken: attestationToken, keyId: keyId)
         } catch {
           Logger.error("App Attest failed: \(error.localizedDescription)")
           resolvedAttestation = nil

--- a/Sources/Authsignal/Models/AppAttestation.swift
+++ b/Sources/Authsignal/Models/AppAttestation.swift
@@ -1,9 +1,9 @@
 public struct AppAttestation: Codable {
-  public let token: String
+  public let attestationToken: String
   public let keyId: String?
 
-  public init(token: String, keyId: String? = nil) {
-    self.token = token
+  public init(attestationToken: String, keyId: String? = nil) {
+    self.attestationToken = attestationToken
     self.keyId = keyId
   }
 }

--- a/Sources/Authsignal/Models/AppAttestation.swift
+++ b/Sources/Authsignal/Models/AppAttestation.swift
@@ -1,14 +1,8 @@
-public enum AppAttestationProvider: String, Codable {
-  case apple
-}
-
 public struct AppAttestation: Codable {
-  public let provider: AppAttestationProvider
   public let token: String
   public let keyId: String?
 
-  public init(provider: AppAttestationProvider, token: String, keyId: String? = nil) {
-    self.provider = provider
+  public init(token: String, keyId: String? = nil) {
     self.token = token
     self.keyId = keyId
   }

--- a/Sources/Authsignal/Models/AppAttestation.swift
+++ b/Sources/Authsignal/Models/AppAttestation.swift
@@ -1,9 +1,0 @@
-public struct AppAttestation: Codable {
-  public let attestationToken: String
-  public let keyId: String?
-
-  public init(attestationToken: String, keyId: String? = nil) {
-    self.attestationToken = attestationToken
-    self.keyId = keyId
-  }
-}

--- a/Sources/Authsignal/Models/DeviceIntegrity.swift
+++ b/Sources/Authsignal/Models/DeviceIntegrity.swift
@@ -1,0 +1,9 @@
+public struct DeviceIntegrity: Codable {
+  public let integrityToken: String
+  public let keyId: String?
+
+  public init(integrityToken: String, keyId: String? = nil) {
+    self.integrityToken = integrityToken
+    self.keyId = keyId
+  }
+}


### PR DESCRIPTION
## Summary
- Renames `appAttestation` to `deviceIntegrity` across public API and internals
- `AppAttestation` struct → `DeviceIntegrity`, `attestationToken` → `integrityToken`
- Internal types and variables updated accordingly
- Provider value `APP_ATTEST` unchanged (Apple-specific identifier)
- Version bumped to 2.4.0-alpha.4

## Test plan
- [ ] Build succeeds
- [ ] App Attest flow works end-to-end with new parameter name