### PR TITLE
[AUT-3359] use nonce instead of idempotency key in attestation

### DIFF
--- a/Authsignal.podspec
+++ b/Authsignal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Authsignal'
-  s.version          = '2.6.0'
+  s.version          = '2.7.0'
   s.summary          = 'The Authsignal SDK for iOS'
 
   s.homepage         = 'https://github.com/authsignal/authsignal-ios'

--- a/Sources/Authsignal/API/BaseAPIClient.swift
+++ b/Sources/Authsignal/API/BaseAPIClient.swift
@@ -11,13 +11,14 @@ class BaseAPIClient {
     self.deviceID = deviceID
   }
 
-  func challenge(action: String? = nil) async -> AuthsignalResponse<ChallengeResponse> {
+  func challenge(action: String? = nil, token: String? = nil) async -> AuthsignalResponse<ChallengeResponse> {
     let url = "\(baseURL)/client/challenge"
 
     let body = ChallengeRequest(action: action)
 
-    return await postRequest(url: url, body: body)
+    return await postRequest(url: url, body: body, token: token)
   }
+  
 
   func getRequest<T: Decodable>(url: String, token: String? = nil) async -> AuthsignalResponse<T> {
     var request = URLRequest(url: URL(string: url)!)

--- a/Sources/Authsignal/API/Models/ChallengeResponse.swift
+++ b/Sources/Authsignal/API/Models/ChallengeResponse.swift
@@ -1,3 +1,4 @@
 public struct ChallengeResponse: Codable {
   public let challengeId: String
+  public let nonce: String?
 }

--- a/Sources/Authsignal/AppAttestation.swift
+++ b/Sources/Authsignal/AppAttestation.swift
@@ -12,10 +12,10 @@ class AppAttestation {
       return AuthsignalResponse(error: challengeResponse.error ?? "Error generating challenge.")
     }
 
-    return AuthsignalResponse(data: await resolve(nonce: nonce))
+    return AuthsignalResponse(data: await attest(nonce: nonce))
   }
 
-  private static func resolve(nonce: String) async -> AppAttestationResult? {
+  private static func attest(nonce: String) async -> AppAttestationResult? {
     if #available(iOS 14.0, *), DCAppAttestService.shared.isSupported {
       do {
         let nonceData = Data(nonce.utf8)

--- a/Sources/Authsignal/AppAttestation.swift
+++ b/Sources/Authsignal/AppAttestation.swift
@@ -3,7 +3,19 @@ import DeviceCheck
 import CryptoKit
 
 class AppAttestation {
-  static func resolve(nonce: String) async -> AppAttestationResult? {
+  static func resolve(api: BaseAPIClient, token: String, performAttestation: Bool) async -> AuthsignalResponse<AppAttestationResult?> {
+    guard performAttestation else { return AuthsignalResponse(data: nil) }
+
+    let challengeResponse = await api.challenge(token: token)
+
+    guard let nonce = challengeResponse.data?.nonce else {
+      return AuthsignalResponse(error: challengeResponse.error ?? "Error generating challenge.")
+    }
+
+    return AuthsignalResponse(data: await resolve(nonce: nonce))
+  }
+
+  private static func resolve(nonce: String) async -> AppAttestationResult? {
     if #available(iOS 14.0, *), DCAppAttestService.shared.isSupported {
       do {
         let nonceData = Data(nonce.utf8)
@@ -20,17 +32,5 @@ class AppAttestation {
     }
 
     return nil
-  }
-
-  private static func extractIdempotencyKey(from token: String) -> String? {
-    let parts = token.split(separator: ".")
-    guard parts.count >= 2 else { return nil }
-
-    let payload = String(parts[1]).base64URLUnescaped()
-    guard let data = Data(base64Encoded: payload) else { return nil }
-    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
-    guard let other = json["other"] as? [String: Any] else { return nil }
-
-    return other["idempotencyKey"] as? String
   }
 }

--- a/Sources/Authsignal/AppAttestation.swift
+++ b/Sources/Authsignal/AppAttestation.swift
@@ -12,7 +12,9 @@ class AppAttestation {
       return AuthsignalResponse(error: challengeResponse.error ?? "Error generating challenge.")
     }
 
-    return AuthsignalResponse(data: await attest(nonce: nonce))
+    let attestationResult = await attest(nonce: nonce)
+
+    return AuthsignalResponse(data: attestationResult)
   }
 
   private static func attest(nonce: String) async -> AppAttestationResult? {

--- a/Sources/Authsignal/AppAttestation.swift
+++ b/Sources/Authsignal/AppAttestation.swift
@@ -3,15 +3,10 @@ import DeviceCheck
 import CryptoKit
 
 class AppAttestation {
-  static func resolve(token: String) async -> AppAttestationResult? {
+  static func resolve(nonce: String) async -> AppAttestationResult? {
     if #available(iOS 14.0, *), DCAppAttestService.shared.isSupported {
       do {
-        guard let idempotencyKey = extractIdempotencyKey(from: token) else {
-          Logger.error("Failed to extract idempotencyKey from token")
-          return nil
-        }
-
-        let nonceData = Data(idempotencyKey.utf8)
+        let nonceData = Data(nonce.utf8)
         let nonceHash = Data(SHA256.hash(data: nonceData))
 
         let keyId = try await DCAppAttestService.shared.generateKey()

--- a/Sources/Authsignal/AuthsignalInApp.swift
+++ b/Sources/Authsignal/AuthsignalInApp.swift
@@ -56,17 +56,13 @@ public class AuthsignalInApp {
       return AuthsignalResponse(errorCode: SdkErrorCodes.createKeyPairFailed)
     }
 
-    var attestationResult: AppAttestationResult? = nil
+    let attestationResponse = await AppAttestation.resolve(api: api, token: userToken, performAttestation: performAttestation)
 
-    if performAttestation {
-      let challengeResponse = await api.challenge(token: userToken)
-
-      guard let nonce = challengeResponse.data?.nonce else {
-        return AuthsignalResponse(error: challengeResponse.error ?? "Error generating challenge.")
-      }
-
-      attestationResult = await AppAttestation.resolve(nonce: nonce)
+    if let error = attestationResponse.error {
+      return AuthsignalResponse(error: error, errorCode: attestationResponse.errorCode)
     }
+
+    let attestationResult = attestationResponse.data ?? nil
 
     let deviceName = await UIDevice.current.name
 

--- a/Sources/Authsignal/AuthsignalInApp.swift
+++ b/Sources/Authsignal/AuthsignalInApp.swift
@@ -56,7 +56,11 @@ public class AuthsignalInApp {
       return AuthsignalResponse(errorCode: SdkErrorCodes.createKeyPairFailed)
     }
 
-    let attestationResult = performAttestation ? await AppAttestation.resolve(token: userToken) : nil
+    let challengeResponse = await api.challenge(token: userToken)
+
+    let nonce = challengeResponse.data?.nonce
+
+    let attestationResult = performAttestation ? await AppAttestation.resolve(nonce: nonce) : nil
 
     let deviceName = await UIDevice.current.name
 

--- a/Sources/Authsignal/AuthsignalInApp.swift
+++ b/Sources/Authsignal/AuthsignalInApp.swift
@@ -56,11 +56,17 @@ public class AuthsignalInApp {
       return AuthsignalResponse(errorCode: SdkErrorCodes.createKeyPairFailed)
     }
 
-    let challengeResponse = await api.challenge(token: userToken)
+    var attestationResult: AppAttestationResult? = nil
 
-    let nonce = challengeResponse.data?.nonce
+    if performAttestation {
+      let challengeResponse = await api.challenge(token: userToken)
 
-    let attestationResult = performAttestation ? await AppAttestation.resolve(nonce: nonce) : nil
+      guard let nonce = challengeResponse.data?.nonce else {
+        return AuthsignalResponse(error: challengeResponse.error ?? "Error generating challenge.")
+      }
+
+      attestationResult = await AppAttestation.resolve(nonce: nonce)
+    }
 
     let deviceName = await UIDevice.current.name
 

--- a/Sources/Authsignal/AuthsignalPush.swift
+++ b/Sources/Authsignal/AuthsignalPush.swift
@@ -51,7 +51,17 @@ public class AuthsignalPush {
       return AuthsignalResponse(errorCode: SdkErrorCodes.createKeyPairFailed)
     }
 
-    let attestationResult = performAttestation ? await AppAttestation.resolve(token: userToken) : nil
+    var attestationResult: AppAttestationResult? = nil
+
+    if performAttestation {
+      let challengeResponse = await api.challenge(token: userToken)
+
+      guard let nonce = challengeResponse.data?.nonce else {
+        return AuthsignalResponse(error: challengeResponse.error ?? "Error generating challenge.")
+      }
+
+      attestationResult = await AppAttestation.resolve(nonce: nonce)
+    }
 
     let deviceName = await UIDevice.current.name
 

--- a/Sources/Authsignal/AuthsignalPush.swift
+++ b/Sources/Authsignal/AuthsignalPush.swift
@@ -51,17 +51,13 @@ public class AuthsignalPush {
       return AuthsignalResponse(errorCode: SdkErrorCodes.createKeyPairFailed)
     }
 
-    var attestationResult: AppAttestationResult? = nil
+    let attestationResponse = await AppAttestation.resolve(api: api, token: userToken, performAttestation: performAttestation)
 
-    if performAttestation {
-      let challengeResponse = await api.challenge(token: userToken)
-
-      guard let nonce = challengeResponse.data?.nonce else {
-        return AuthsignalResponse(error: challengeResponse.error ?? "Error generating challenge.")
-      }
-
-      attestationResult = await AppAttestation.resolve(nonce: nonce)
+    if let error = attestationResponse.error {
+      return AuthsignalResponse(error: error, errorCode: attestationResponse.errorCode)
     }
+
+    let attestationResult = attestationResponse.data ?? nil
 
     let deviceName = await UIDevice.current.name
 

--- a/Sources/Authsignal/AuthsignalQRCode.swift
+++ b/Sources/Authsignal/AuthsignalQRCode.swift
@@ -51,7 +51,17 @@ public class AuthsignalQRCode {
       return AuthsignalResponse(errorCode: SdkErrorCodes.createKeyPairFailed)
     }
 
-    let attestationResult = performAttestation ? await AppAttestation.resolve(token: userToken) : nil
+    var attestationResult: AppAttestationResult? = nil
+
+    if performAttestation {
+      let challengeResponse = await api.challenge(token: userToken)
+
+      guard let nonce = challengeResponse.data?.nonce else {
+        return AuthsignalResponse(error: challengeResponse.error ?? "Error generating challenge.")
+      }
+
+      attestationResult = await AppAttestation.resolve(nonce: nonce)
+    }
 
     let deviceName = await UIDevice.current.name
 

--- a/Sources/Authsignal/AuthsignalQRCode.swift
+++ b/Sources/Authsignal/AuthsignalQRCode.swift
@@ -51,17 +51,13 @@ public class AuthsignalQRCode {
       return AuthsignalResponse(errorCode: SdkErrorCodes.createKeyPairFailed)
     }
 
-    var attestationResult: AppAttestationResult? = nil
+    let attestationResponse = await AppAttestation.resolve(api: api, token: userToken, performAttestation: performAttestation)
 
-    if performAttestation {
-      let challengeResponse = await api.challenge(token: userToken)
-
-      guard let nonce = challengeResponse.data?.nonce else {
-        return AuthsignalResponse(error: challengeResponse.error ?? "Error generating challenge.")
-      }
-
-      attestationResult = await AppAttestation.resolve(nonce: nonce)
+    if let error = attestationResponse.error {
+      return AuthsignalResponse(error: error, errorCode: attestationResponse.errorCode)
     }
+
+    let attestationResult = attestationResponse.data ?? nil
 
     let deviceName = await UIDevice.current.name
 


### PR DESCRIPTION
## Summary
- App Attest now signs the server-issued `nonce` from `POST /client/challenge` instead of extracting `idempotencyKey` from the user token.
- `/client/challenge` is now called with the user token so the server returns a `nonce`; `ChallengeResponse` gains an optional `nonce` field.
- Bumps version to 2.7.0 (requires matching server support for nonce-based attestation verification).