### PR TITLE
feat: accept optional pushToken on push enrollment

### DIFF
--- a/Authsignal.podspec
+++ b/Authsignal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Authsignal'
-  s.version          = '2.7.0'
+  s.version          = '2.8.0'
   s.summary          = 'The Authsignal SDK for iOS'
 
   s.homepage         = 'https://github.com/authsignal/authsignal-ios'

--- a/Sources/Authsignal/API/Models/App/AddCredentialRequest.swift
+++ b/Sources/Authsignal/API/Models/App/AddCredentialRequest.swift
@@ -2,17 +2,20 @@ public struct AddCredentialRequest: Codable {
   public let publicKey: String
   public let deviceName: String
   public let devicePlatform: String
+  public let pushToken: String?
   let performAttestation: AddCredentialAttestation?
 
   public init(
     publicKey: String,
     deviceName: String,
     devicePlatform: String,
+    pushToken: String? = nil,
     performAttestation: AppAttestationResult? = nil
   ) {
     self.publicKey = publicKey
     self.deviceName = deviceName
     self.devicePlatform = devicePlatform
+    self.pushToken = pushToken
     self.performAttestation = performAttestation.map {
       AddCredentialAttestation(provider: "APP_ATTEST", token: $0.integrityToken, keyId: $0.keyId)
     }

--- a/Sources/Authsignal/API/PushAPIClient.swift
+++ b/Sources/Authsignal/API/PushAPIClient.swift
@@ -13,6 +13,7 @@ class PushAPIClient: BaseAPIClient {
     token: String,
     publicKey: String,
     deviceName: String,
+    pushToken: String? = nil,
     performAttestation: AppAttestationResult? = nil
   ) async -> AuthsignalResponse<AddCredentialResponse>
   {
@@ -22,6 +23,7 @@ class PushAPIClient: BaseAPIClient {
       publicKey: publicKey,
       deviceName: deviceName,
       devicePlatform: "ios",
+      pushToken: pushToken,
       performAttestation: performAttestation
     )
 

--- a/Sources/Authsignal/AuthsignalPush.swift
+++ b/Sources/Authsignal/AuthsignalPush.swift
@@ -40,7 +40,8 @@ public class AuthsignalPush {
     token: String? = nil,
     keychainAccess: KeychainAccess = .whenUnlockedThisDeviceOnly,
     userPresenceRequired: Bool = false,
-    performAttestation: Bool = false
+    performAttestation: Bool = false,
+    pushToken: String? = nil
   ) async -> AuthsignalResponse<AppCredential> {
     guard let userToken = token ?? cache.token else { return cache.handleTokenNotSetError() }
 
@@ -65,6 +66,7 @@ public class AuthsignalPush {
       token: userToken,
       publicKey: publicKey,
       deviceName: deviceName,
+      pushToken: pushToken,
       performAttestation: attestationResult
     )
     


### PR DESCRIPTION
## Summary

Adds an optional `pushToken: String? = nil` parameter to `AuthsignalPush.addCredential(...)` and threads it through `PushAPIClient.addCredential(...)` into the `AddCredentialRequest` body sent to `POST /v1/client/user-authenticators/push`.