### PR TITLE
Add request metadata headers

### DIFF
--- a/Authsignal.podspec
+++ b/Authsignal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Authsignal'
-  s.version          = '2.8.0'
+  s.version          = '2.8.1'
   s.summary          = 'The Authsignal SDK for iOS'
 
   s.homepage         = 'https://github.com/authsignal/authsignal-ios'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check out our [official iOS documentation](https://docs.authsignal.com/sdks/clie
 Add Authsignal to your Podfile:
 
 ```rb
-pod 'Authsignal', '~> 2.3.0'
+pod 'Authsignal', '~> 2.8.1'
 ```
 
 #### Swift Package Manager
@@ -20,7 +20,7 @@ Add authsignal-ios to the dependencies value of your Package.swift.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/authsignal/authsignal-ios.git", from: "2.3.0")
+    .package(url: "https://github.com/authsignal/authsignal-ios.git", from: "2.8.1")
 ]
 ```
 

--- a/Sources/Authsignal/API/BaseAPIClient.swift
+++ b/Sources/Authsignal/API/BaseAPIClient.swift
@@ -2,11 +2,13 @@ import Foundation
 
 class BaseAPIClient {
   let baseURL: String
+  let tenantID: String
   let basicAuth: String
   let deviceID: String?
 
   public init(tenantID: String, baseURL: String, deviceID: String? = nil) {
     self.baseURL = baseURL
+    self.tenantID = tenantID
     self.basicAuth = "Basic \(Data( "\(tenantID):".utf8).base64URLEncodedString())"
     self.deviceID = deviceID
   }
@@ -30,6 +32,8 @@ class BaseAPIClient {
     } else {
       request.setValue(basicAuth, forHTTPHeaderField: "Authorization")
     }
+
+    applyDefaultHeaders(to: &request)
   
     return await performRequest(request: request)
   }
@@ -39,6 +43,7 @@ class BaseAPIClient {
 
     request.httpMethod = "POST"
     request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    applyDefaultHeaders(to: &request)
 
     return await performRequest(request: request)
   }
@@ -63,7 +68,15 @@ class BaseAPIClient {
       request.httpBody = encodedBody
     }
 
+    applyDefaultHeaders(to: &request)
+
     return await performRequest(request: request)
+  }
+
+  private func applyDefaultHeaders(to request: inout URLRequest) {
+    AuthsignalRequestMetadata.headers(tenantID: tenantID).forEach { name, value in
+      request.setValue(value, forHTTPHeaderField: name)
+    }
   }
 
   private func performRequest<T: Decodable>(request: URLRequest) async -> AuthsignalResponse<T> {

--- a/Sources/Authsignal/AuthsignalRequestMetadata.swift
+++ b/Sources/Authsignal/AuthsignalRequestMetadata.swift
@@ -1,0 +1,66 @@
+import Foundation
+import UIKit
+
+struct AuthsignalWrapperSDKMetadata {
+  let sdk: String
+  let version: String
+  let userAgentToken: String
+}
+
+@objc public class AuthsignalRequestMetadata: NSObject {
+  private static let nativeSDK = "ios"
+  private static let nativeVersion = "2.8.1"
+  private static let nativeUserAgentToken = "AuthsignalIOSSDK"
+  private static var wrapperSDKMetadata: AuthsignalWrapperSDKMetadata?
+
+  @objc public static func setWrapperSDK(_ sdk: String, version: String, userAgentToken: String) {
+    wrapperSDKMetadata = AuthsignalWrapperSDKMetadata(
+      sdk: sdk,
+      version: version,
+      userAgentToken: userAgentToken
+    )
+  }
+
+  @objc public static func clearWrapperSDK() {
+    wrapperSDKMetadata = nil
+  }
+
+  static func headers(tenantID: String) -> [String: String] {
+    var headers = [
+      "User-Agent": userAgent(),
+      "X-Authsignal-SDK": wrapperSDKMetadata?.sdk ?? nativeSDK,
+      "X-Authsignal-Version": wrapperSDKMetadata?.version ?? nativeVersion,
+      "X-Authsignal-Tenant-ID": tenantID,
+    ]
+
+    if wrapperSDKMetadata != nil {
+      headers["X-Authsignal-Native-SDK"] = nativeSDK
+      headers["X-Authsignal-Native-Version"] = nativeVersion
+    }
+
+    return headers
+  }
+
+  private static func userAgent() -> String {
+    "\(baseUserAgent()) \(userAgentProductTokens())"
+  }
+
+  private static func userAgentProductTokens() -> String {
+    let nativeProduct = "\(nativeUserAgentToken)/\(nativeVersion)"
+
+    if let wrapperSDKMetadata = wrapperSDKMetadata {
+      return "\(wrapperSDKMetadata.userAgentToken)/\(wrapperSDKMetadata.version) \(nativeProduct)"
+    }
+
+    return nativeProduct
+  }
+
+  private static func baseUserAgent() -> String {
+    let device = UIDevice.current
+    let platform = device.userInterfaceIdiom == .pad ? "iPad" : "iPhone"
+    let osPrefix = platform == "iPad" ? "CPU OS" : "CPU iPhone OS"
+    let osVersion = device.systemVersion.replacingOccurrences(of: ".", with: "_")
+
+    return "Mozilla/5.0 (\(platform); \(osPrefix) \(osVersion) like Mac OS X)"
+  }
+}


### PR DESCRIPTION
### New Features
- Adds standard Authsignal request metadata headers to iOS API requests, including a parseable Authsignal iOS User-Agent. 


### Checklist
- [x] Version bumped