### PR TITLE
Add push credential update (AUT-3560)

### DIFF
--- a/Authsignal.podspec
+++ b/Authsignal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Authsignal'
-  s.version          = '2.10.0'
+  s.version          = '2.11.0'
   s.summary          = 'The Authsignal SDK for iOS'
 
   s.homepage         = 'https://github.com/authsignal/authsignal-ios'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check out our [official iOS documentation](https://docs.authsignal.com/sdks/clie
 Add Authsignal to your Podfile:
 
 ```rb
-pod 'Authsignal', '~> 2.10.0'
+pod 'Authsignal', '~> 2.11.0'
 ```
 
 #### Swift Package Manager
@@ -20,7 +20,7 @@ Add authsignal-ios to the dependencies value of your Package.swift.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/authsignal/authsignal-ios.git", from: "2.10.0")
+    .package(url: "https://github.com/authsignal/authsignal-ios.git", from: "2.11.0")
 ]
 ```
 

--- a/Sources/Authsignal/API/BaseAPIClient.swift
+++ b/Sources/Authsignal/API/BaseAPIClient.swift
@@ -83,6 +83,31 @@ class BaseAPIClient {
     return await performRequest(request: request)
   }
 
+  func patchRequest<T: Decodable, TBody: Encodable>(url: String, body: TBody, token: String? = nil)
+    async -> AuthsignalResponse<T>
+  {
+    var request = URLRequest(url: URL(string: url)!)
+
+    request.httpMethod = "PATCH"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+    if let token = token {
+      request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    } else {
+      request.setValue(basicAuth, forHTTPHeaderField: "Authorization")
+    }
+
+    let encoder = JSONEncoder()
+
+    if let encodedBody = try? encoder.encode(body) {
+      request.httpBody = encodedBody
+    }
+
+    applyDefaultHeaders(to: &request)
+
+    return await performRequest(request: request)
+  }
+
   private func applyDefaultHeaders(to request: inout URLRequest) {
     AuthsignalRequestMetadata.headers(tenantID: tenantID).forEach { name, value in
       request.setValue(value, forHTTPHeaderField: name)

--- a/Sources/Authsignal/API/Models/App/SigningMessageResponse.swift
+++ b/Sources/Authsignal/API/Models/App/SigningMessageResponse.swift
@@ -1,4 +1,4 @@
-public struct UpdateNonceResponse: Codable {
+public struct SigningMessageResponse: Codable {
   public let challengeId: String?
   public let message: String?
 }

--- a/Sources/Authsignal/API/Models/App/UpdateCredentialRequest.swift
+++ b/Sources/Authsignal/API/Models/App/UpdateCredentialRequest.swift
@@ -1,0 +1,6 @@
+public struct UpdateCredentialRequest: Codable {
+  public let challengeId: String
+  public let publicKey: String
+  public let signature: String
+  public let pushToken: String
+}

--- a/Sources/Authsignal/API/Models/App/UpdateCredentialResponse.swift
+++ b/Sources/Authsignal/API/Models/App/UpdateCredentialResponse.swift
@@ -1,0 +1,6 @@
+public struct UpdateCredentialResponse: Codable {
+  public let userAuthenticatorId: String
+  public let userId: String
+  public let lastVerifiedAt: String
+  public let pushToken: String
+}

--- a/Sources/Authsignal/API/Models/App/UpdateNonceResponse.swift
+++ b/Sources/Authsignal/API/Models/App/UpdateNonceResponse.swift
@@ -1,0 +1,4 @@
+public struct UpdateNonceResponse: Codable {
+  public let challengeId: String?
+  public let message: String?
+}

--- a/Sources/Authsignal/API/PushAPIClient.swift
+++ b/Sources/Authsignal/API/PushAPIClient.swift
@@ -69,7 +69,7 @@ class PushAPIClient: BaseAPIClient {
     return await postRequest(url: url)
   }
 
-  public func getSigningMessage(publicKey: String) async -> AuthsignalResponse<UpdateNonceResponse> {
+  public func getSigningMessage(publicKey: String) async -> AuthsignalResponse<SigningMessageResponse> {
     let encodedKey = Data(publicKey.utf8).base64URLEncodedString()
 
     let url = "\(baseURL)/client/user-authenticators/push/update/sign?publicKey=\(encodedKey)"

--- a/Sources/Authsignal/API/PushAPIClient.swift
+++ b/Sources/Authsignal/API/PushAPIClient.swift
@@ -72,7 +72,7 @@ class PushAPIClient: BaseAPIClient {
   public func getSigningMessage(publicKey: String) async -> AuthsignalResponse<SigningMessageResponse> {
     let encodedKey = Data(publicKey.utf8).base64URLEncodedString()
 
-    let url = "\(baseURL)/client/user-authenticators/push/update/sign?publicKey=\(encodedKey)"
+    let url = "\(baseURL)/client/user-authenticators/push/sign?publicKey=\(encodedKey)"
 
     return await postRequest(url: url)
   }

--- a/Sources/Authsignal/API/PushAPIClient.swift
+++ b/Sources/Authsignal/API/PushAPIClient.swift
@@ -83,7 +83,7 @@ class PushAPIClient: BaseAPIClient {
     signature: String,
     pushToken: String
   ) async -> AuthsignalResponse<UpdateCredentialResponse> {
-    let url = "\(baseURL)/client/user-authenticators/push/update"
+    let url = "\(baseURL)/client/user-authenticators/push"
 
     let body = UpdateCredentialRequest(
       challengeId: challengeId,
@@ -92,7 +92,7 @@ class PushAPIClient: BaseAPIClient {
       pushToken: pushToken
     )
 
-    return await postRequest(url: url, body: body)
+    return await patchRequest(url: url, body: body)
   }
 
   public func updateChallenge(

--- a/Sources/Authsignal/API/PushAPIClient.swift
+++ b/Sources/Authsignal/API/PushAPIClient.swift
@@ -69,6 +69,32 @@ class PushAPIClient: BaseAPIClient {
     return await postRequest(url: url)
   }
 
+  public func getSigningMessage(publicKey: String) async -> AuthsignalResponse<UpdateNonceResponse> {
+    let encodedKey = Data(publicKey.utf8).base64URLEncodedString()
+
+    let url = "\(baseURL)/client/user-authenticators/push/update/sign?publicKey=\(encodedKey)"
+
+    return await postRequest(url: url)
+  }
+
+  public func updateCredential(
+    challengeId: String,
+    publicKey: String,
+    signature: String,
+    pushToken: String
+  ) async -> AuthsignalResponse<UpdateCredentialResponse> {
+    let url = "\(baseURL)/client/user-authenticators/push/update"
+
+    let body = UpdateCredentialRequest(
+      challengeId: challengeId,
+      publicKey: publicKey,
+      signature: signature,
+      pushToken: pushToken
+    )
+
+    return await postRequest(url: url, body: body)
+  }
+
   public func updateChallenge(
     challengeId: String,
     publicKey: String,

--- a/Sources/Authsignal/AuthsignalPush.swift
+++ b/Sources/Authsignal/AuthsignalPush.swift
@@ -151,6 +151,51 @@ public class AuthsignalPush {
     return AuthsignalResponse(data: pushChallenge)
   }
 
+  public func updateCredential(pushToken: String) async -> AuthsignalResponse<AppCredential> {
+    let secKey = keyManager.getKey()
+    let publicKey = keyManager.getPublicKey()
+
+    guard let secKey = secKey, let publicKey = publicKey else {
+      return AuthsignalResponse(errorCode: SdkErrorCodes.credentialNotFound)
+    }
+
+    let nonceResponse = await api.getSigningMessage(publicKey: publicKey)
+
+    guard let challengeId = nonceResponse.data?.challengeId, let nonce = nonceResponse.data?.message else {
+      return AuthsignalResponse(error: nonceResponse.error, errorCode: nonceResponse.errorCode)
+    }
+
+    let signatureResponse = Signature.sign(message: nonce, privateKey: secKey)
+
+    guard let signature = signatureResponse.data else {
+      return AuthsignalResponse(error: signatureResponse.error)
+    }
+
+    let response = await api.updateCredential(
+      challengeId: challengeId,
+      publicKey: publicKey,
+      signature: signature,
+      pushToken: pushToken
+    )
+
+    if let error = response.error {
+      return AuthsignalResponse(error: error, errorCode: response.errorCode)
+    }
+
+    guard let data = response.data else {
+      return AuthsignalResponse(error: response.error, errorCode: response.errorCode)
+    }
+
+    let credential = AppCredential(
+      credentialId: data.userAuthenticatorId,
+      createdAt: data.lastVerifiedAt,
+      userId: data.userId,
+      lastAuthenticatedAt: data.lastVerifiedAt
+    )
+
+    return AuthsignalResponse(data: credential)
+  }
+
   public func updateChallenge(
     challengeId: String,
     approved: Bool,

--- a/Sources/Authsignal/AuthsignalPush.swift
+++ b/Sources/Authsignal/AuthsignalPush.swift
@@ -151,7 +151,7 @@ public class AuthsignalPush {
     return AuthsignalResponse(data: pushChallenge)
   }
 
-  public func updateCredential(pushToken: String) async -> AuthsignalResponse<AppCredential> {
+  public func updateCredential(pushToken: String) async -> AuthsignalResponse<UpdateCredentialResponse> {
     let secKey = keyManager.getKey()
     let publicKey = keyManager.getPublicKey()
 
@@ -161,10 +161,15 @@ public class AuthsignalPush {
 
     let signingMessageResponse = await api.getSigningMessage(publicKey: publicKey)
 
+    if let error = signingMessageResponse.error {
+      return AuthsignalResponse(error: error, errorCode: signingMessageResponse.errorCode)
+    }
+
+    // A 200 with missing fields is a protocol error, not a silent no-op.
     guard let challengeId = signingMessageResponse.data?.challengeId,
           let messageToSign = signingMessageResponse.data?.message
     else {
-      return AuthsignalResponse(error: signingMessageResponse.error, errorCode: signingMessageResponse.errorCode)
+      return AuthsignalResponse(error: "Invalid signing message response.")
     }
 
     let signatureResponse = Signature.sign(message: messageToSign, privateKey: secKey)
@@ -185,17 +190,10 @@ public class AuthsignalPush {
     }
 
     guard let data = response.data else {
-      return AuthsignalResponse(error: response.error, errorCode: response.errorCode)
+      return AuthsignalResponse(error: "Invalid update credential response.")
     }
 
-    let credential = AppCredential(
-      credentialId: data.userAuthenticatorId,
-      createdAt: data.lastVerifiedAt,
-      userId: data.userId,
-      lastAuthenticatedAt: data.lastVerifiedAt
-    )
-
-    return AuthsignalResponse(data: credential)
+    return AuthsignalResponse(data: data)
   }
 
   public func updateChallenge(

--- a/Sources/Authsignal/AuthsignalPush.swift
+++ b/Sources/Authsignal/AuthsignalPush.swift
@@ -159,13 +159,15 @@ public class AuthsignalPush {
       return AuthsignalResponse(errorCode: SdkErrorCodes.credentialNotFound)
     }
 
-    let nonceResponse = await api.getSigningMessage(publicKey: publicKey)
+    let signingMessageResponse = await api.getSigningMessage(publicKey: publicKey)
 
-    guard let challengeId = nonceResponse.data?.challengeId, let nonce = nonceResponse.data?.message else {
-      return AuthsignalResponse(error: nonceResponse.error, errorCode: nonceResponse.errorCode)
+    guard let challengeId = signingMessageResponse.data?.challengeId,
+          let messageToSign = signingMessageResponse.data?.message
+    else {
+      return AuthsignalResponse(error: signingMessageResponse.error, errorCode: signingMessageResponse.errorCode)
     }
 
-    let signatureResponse = Signature.sign(message: nonce, privateKey: secKey)
+    let signatureResponse = Signature.sign(message: messageToSign, privateKey: secKey)
 
     guard let signature = signatureResponse.data else {
       return AuthsignalResponse(error: signatureResponse.error)

--- a/Sources/Authsignal/AuthsignalRequestMetadata.swift
+++ b/Sources/Authsignal/AuthsignalRequestMetadata.swift
@@ -9,7 +9,7 @@ struct AuthsignalWrapperSDKMetadata {
 
 @objc public class AuthsignalRequestMetadata: NSObject {
   private static let nativeSDK = "ios"
-  private static let nativeVersion = "2.8.1"
+  private static let nativeVersion = "2.11.0"
   private static let nativeUserAgentToken = "AuthsignalIOSSDK"
   private static var wrapperSDKMetadata: AuthsignalWrapperSDKMetadata?
 


### PR DESCRIPTION
Adds `AuthsignalPush.updateCredential(pushToken:)` so an enrolled device can refresh its push (FCM/APNs) token.

The device proves possession of its credential by signing a server-issued single-use nonce; the backend verifies the signature against the public key on file before applying the update. No user session or track call required.

Flow:
1. Request a signing message (nonce) for the credential.
2. Sign it with the credential's private key (ECDSA P-256 / SHA-256).
3. Send the signed update; the backend verifies and refreshes the token.

Adds `PushAPIClient.getSigningMessage` / `updateCredential` and the request/response models. Version bumped 2.10.0 → 2.11.0.

Requires the backend endpoints from authsignal-serverless#2645 (`POST /push/sign` + `PATCH /push`). Must be released together with that PR.