### PR TITLE
feat(push): resetExpiry flag + optional pushToken (AUT-3577)

### DIFF
--- a/Authsignal.podspec
+++ b/Authsignal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Authsignal'
-  s.version          = '2.11.0'
+  s.version          = '2.12.0'
   s.summary          = 'The Authsignal SDK for iOS'
 
   s.homepage         = 'https://github.com/authsignal/authsignal-ios'

--- a/Sources/Authsignal/API/Models/App/CredentialResponse.swift
+++ b/Sources/Authsignal/API/Models/App/CredentialResponse.swift
@@ -3,5 +3,5 @@ public struct CredentialResponse: Codable {
   public let verifiedAt: String
   public let userId: String
   public let lastVerifiedAt: String?
-  public let expiresAt: String?
+  public let expiresAt: Double?
 }

--- a/Sources/Authsignal/API/Models/App/CredentialResponse.swift
+++ b/Sources/Authsignal/API/Models/App/CredentialResponse.swift
@@ -3,4 +3,5 @@ public struct CredentialResponse: Codable {
   public let verifiedAt: String
   public let userId: String
   public let lastVerifiedAt: String?
+  public let expiresAt: String?
 }

--- a/Sources/Authsignal/API/Models/App/CredentialResponse.swift
+++ b/Sources/Authsignal/API/Models/App/CredentialResponse.swift
@@ -3,5 +3,5 @@ public struct CredentialResponse: Codable {
   public let verifiedAt: String
   public let userId: String
   public let lastVerifiedAt: String?
-  public let expiresAt: Double?
+  public let expiresAt: String?
 }

--- a/Sources/Authsignal/API/Models/App/UpdateCredentialRequest.swift
+++ b/Sources/Authsignal/API/Models/App/UpdateCredentialRequest.swift
@@ -2,5 +2,20 @@ public struct UpdateCredentialRequest: Codable {
   public let challengeId: String
   public let publicKey: String
   public let signature: String
-  public let pushToken: String
+  public let pushToken: String?
+  public let extend: Bool?
+
+  public init(
+    challengeId: String,
+    publicKey: String,
+    signature: String,
+    pushToken: String? = nil,
+    extend: Bool? = nil
+  ) {
+    self.challengeId = challengeId
+    self.publicKey = publicKey
+    self.signature = signature
+    self.pushToken = pushToken
+    self.extend = extend
+  }
 }

--- a/Sources/Authsignal/API/Models/App/UpdateCredentialRequest.swift
+++ b/Sources/Authsignal/API/Models/App/UpdateCredentialRequest.swift
@@ -3,19 +3,19 @@ public struct UpdateCredentialRequest: Codable {
   public let publicKey: String
   public let signature: String
   public let pushToken: String?
-  public let extend: Bool?
+  public let resetExpiry: Bool?
 
   public init(
     challengeId: String,
     publicKey: String,
     signature: String,
     pushToken: String? = nil,
-    extend: Bool? = nil
+    resetExpiry: Bool? = nil
   ) {
     self.challengeId = challengeId
     self.publicKey = publicKey
     self.signature = signature
     self.pushToken = pushToken
-    self.extend = extend
+    self.resetExpiry = resetExpiry
   }
 }

--- a/Sources/Authsignal/API/Models/App/UpdateCredentialResponse.swift
+++ b/Sources/Authsignal/API/Models/App/UpdateCredentialResponse.swift
@@ -2,7 +2,6 @@ public struct UpdateCredentialResponse: Codable {
   public let userAuthenticatorId: String
   public let userId: String
   public let lastVerifiedAt: String
-  // Echoes the request's pushToken; absent for keep-alive calls that omit the token.
   public let pushToken: String?
-  public let expiresAt: String?
+  public let expiresAt: Double?
 }

--- a/Sources/Authsignal/API/Models/App/UpdateCredentialResponse.swift
+++ b/Sources/Authsignal/API/Models/App/UpdateCredentialResponse.swift
@@ -3,5 +3,5 @@ public struct UpdateCredentialResponse: Codable {
   public let userId: String
   public let lastVerifiedAt: String
   public let pushToken: String?
-  public let expiresAt: Double?
+  public let expiresAt: String?
 }

--- a/Sources/Authsignal/API/Models/App/UpdateCredentialResponse.swift
+++ b/Sources/Authsignal/API/Models/App/UpdateCredentialResponse.swift
@@ -2,5 +2,7 @@ public struct UpdateCredentialResponse: Codable {
   public let userAuthenticatorId: String
   public let userId: String
   public let lastVerifiedAt: String
-  public let pushToken: String
+  // Echoes the request's pushToken; absent for keep-alive calls that omit the token.
+  public let pushToken: String?
+  public let expiresAt: String?
 }

--- a/Sources/Authsignal/API/PushAPIClient.swift
+++ b/Sources/Authsignal/API/PushAPIClient.swift
@@ -81,7 +81,8 @@ class PushAPIClient: BaseAPIClient {
     challengeId: String,
     publicKey: String,
     signature: String,
-    pushToken: String
+    pushToken: String? = nil,
+    extend: Bool? = nil
   ) async -> AuthsignalResponse<UpdateCredentialResponse> {
     let url = "\(baseURL)/client/user-authenticators/push"
 
@@ -89,7 +90,8 @@ class PushAPIClient: BaseAPIClient {
       challengeId: challengeId,
       publicKey: publicKey,
       signature: signature,
-      pushToken: pushToken
+      pushToken: pushToken,
+      extend: extend
     )
 
     return await patchRequest(url: url, body: body)

--- a/Sources/Authsignal/API/PushAPIClient.swift
+++ b/Sources/Authsignal/API/PushAPIClient.swift
@@ -82,7 +82,7 @@ class PushAPIClient: BaseAPIClient {
     publicKey: String,
     signature: String,
     pushToken: String? = nil,
-    extend: Bool? = nil
+    resetExpiry: Bool? = nil
   ) async -> AuthsignalResponse<UpdateCredentialResponse> {
     let url = "\(baseURL)/client/user-authenticators/push"
 
@@ -91,7 +91,7 @@ class PushAPIClient: BaseAPIClient {
       publicKey: publicKey,
       signature: signature,
       pushToken: pushToken,
-      extend: extend
+      resetExpiry: resetExpiry
     )
 
     return await patchRequest(url: url, body: body)

--- a/Sources/Authsignal/AuthsignalPush.swift
+++ b/Sources/Authsignal/AuthsignalPush.swift
@@ -30,7 +30,8 @@ public class AuthsignalPush {
       credentialId: data.userAuthenticatorId,
       createdAt: data.verifiedAt,
       userId: data.userId,
-      lastAuthenticatedAt: data.lastVerifiedAt
+      lastAuthenticatedAt: data.lastVerifiedAt,
+      expiresAt: data.expiresAt
     )
 
     return AuthsignalResponse(data: credential)
@@ -151,7 +152,10 @@ public class AuthsignalPush {
     return AuthsignalResponse(data: pushChallenge)
   }
 
-  public func updateCredential(pushToken: String) async -> AuthsignalResponse<UpdateCredentialResponse> {
+  public func updateCredential(
+    pushToken: String? = nil,
+    extend: Bool = false
+  ) async -> AuthsignalResponse<UpdateCredentialResponse> {
     let secKey = keyManager.getKey()
     let publicKey = keyManager.getPublicKey()
 
@@ -182,7 +186,8 @@ public class AuthsignalPush {
       challengeId: challengeId,
       publicKey: publicKey,
       signature: signature,
-      pushToken: pushToken
+      pushToken: pushToken,
+      extend: extend ? true : nil
     )
 
     if let error = response.error {

--- a/Sources/Authsignal/AuthsignalPush.swift
+++ b/Sources/Authsignal/AuthsignalPush.swift
@@ -154,7 +154,7 @@ public class AuthsignalPush {
 
   public func updateCredential(
     pushToken: String? = nil,
-    extend: Bool = false
+    resetExpiry: Bool = false
   ) async -> AuthsignalResponse<UpdateCredentialResponse> {
     let secKey = keyManager.getKey()
     let publicKey = keyManager.getPublicKey()
@@ -187,7 +187,7 @@ public class AuthsignalPush {
       publicKey: publicKey,
       signature: signature,
       pushToken: pushToken,
-      extend: extend ? true : nil
+      resetExpiry: resetExpiry ? true : nil
     )
 
     if let error = response.error {

--- a/Sources/Authsignal/AuthsignalRequestMetadata.swift
+++ b/Sources/Authsignal/AuthsignalRequestMetadata.swift
@@ -9,7 +9,7 @@ struct AuthsignalWrapperSDKMetadata {
 
 @objc public class AuthsignalRequestMetadata: NSObject {
   private static let nativeSDK = "ios"
-  private static let nativeVersion = "2.11.0"
+  private static let nativeVersion = "2.12.0"
   private static let nativeUserAgentToken = "AuthsignalIOSSDK"
   private static var wrapperSDKMetadata: AuthsignalWrapperSDKMetadata?
 

--- a/Sources/Authsignal/Models/AppCredential.swift
+++ b/Sources/Authsignal/Models/AppCredential.swift
@@ -5,14 +5,14 @@ public struct AppCredential: Codable {
   public let createdAt: String
   public let userId: String
   public let lastAuthenticatedAt: String?
-  public let expiresAt: String?
+  public let expiresAt: Double?
 
   public init(
     credentialId: String,
     createdAt: String,
     userId: String,
     lastAuthenticatedAt: String?,
-    expiresAt: String? = nil
+    expiresAt: Double? = nil
   ) {
     self.credentialId = credentialId
     self.createdAt = createdAt
@@ -21,35 +21,11 @@ public struct AppCredential: Codable {
     self.expiresAt = expiresAt
   }
 
-  /// Whether the credential's lease has lapsed, based on `expiresAt`.
-  /// Returns `false` when the server does not provide an expiry (no expiry
-  /// configured) or when the value cannot be parsed (fail-open), matching the
-  /// serverless `isExpired` semantics.
   public var isExpired: Bool {
-    guard let expiresAt = expiresAt,
-          let expiryDate = AppCredential.parseISODate(expiresAt)
-    else {
+    guard let expiresAt = expiresAt else {
       return false
     }
 
-    return expiryDate < Date()
-  }
-
-  /// Parses an ISO 8601 timestamp emitted by the server (Luxon `DateTime.toISO()`),
-  /// which includes fractional seconds and a numeric timezone offset
-  /// (e.g. `2026-06-30T12:42:38.416+12:00`). Falls back to parsing without
-  /// fractional seconds so values that ever lack milliseconds still parse.
-  static func parseISODate(_ value: String) -> Date? {
-    let withFractional = ISO8601DateFormatter()
-    withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-    if let date = withFractional.date(from: value) {
-      return date
-    }
-
-    let withoutFractional = ISO8601DateFormatter()
-    withoutFractional.formatOptions = [.withInternetDateTime]
-
-    return withoutFractional.date(from: value)
+    return Date(timeIntervalSince1970: expiresAt) < Date()
   }
 }

--- a/Sources/Authsignal/Models/AppCredential.swift
+++ b/Sources/Authsignal/Models/AppCredential.swift
@@ -20,12 +20,4 @@ public struct AppCredential: Codable {
     self.lastAuthenticatedAt = lastAuthenticatedAt
     self.expiresAt = expiresAt
   }
-
-  public var isExpired: Bool {
-    guard let expiresAt = expiresAt else {
-      return false
-    }
-
-    return Date(timeIntervalSince1970: expiresAt) < Date()
-  }
 }

--- a/Sources/Authsignal/Models/AppCredential.swift
+++ b/Sources/Authsignal/Models/AppCredential.swift
@@ -5,14 +5,14 @@ public struct AppCredential: Codable {
   public let createdAt: String
   public let userId: String
   public let lastAuthenticatedAt: String?
-  public let expiresAt: Double?
+  public let expiresAt: String?
 
   public init(
     credentialId: String,
     createdAt: String,
     userId: String,
     lastAuthenticatedAt: String?,
-    expiresAt: Double? = nil
+    expiresAt: String? = nil
   ) {
     self.credentialId = credentialId
     self.createdAt = createdAt

--- a/Sources/Authsignal/Models/AppCredential.swift
+++ b/Sources/Authsignal/Models/AppCredential.swift
@@ -22,14 +22,34 @@ public struct AppCredential: Codable {
   }
 
   /// Whether the credential's lease has lapsed, based on `expiresAt`.
-  /// Returns `false` when the server does not provide an expiry (no expiry configured).
+  /// Returns `false` when the server does not provide an expiry (no expiry
+  /// configured) or when the value cannot be parsed (fail-open), matching the
+  /// serverless `isExpired` semantics.
   public var isExpired: Bool {
     guard let expiresAt = expiresAt,
-          let expiryDate = ISO8601DateFormatter().date(from: expiresAt)
+          let expiryDate = AppCredential.parseISODate(expiresAt)
     else {
       return false
     }
 
     return expiryDate < Date()
+  }
+
+  /// Parses an ISO 8601 timestamp emitted by the server (Luxon `DateTime.toISO()`),
+  /// which includes fractional seconds and a numeric timezone offset
+  /// (e.g. `2026-06-30T12:42:38.416+12:00`). Falls back to parsing without
+  /// fractional seconds so values that ever lack milliseconds still parse.
+  static func parseISODate(_ value: String) -> Date? {
+    let withFractional = ISO8601DateFormatter()
+    withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+    if let date = withFractional.date(from: value) {
+      return date
+    }
+
+    let withoutFractional = ISO8601DateFormatter()
+    withoutFractional.formatOptions = [.withInternetDateTime]
+
+    return withoutFractional.date(from: value)
   }
 }

--- a/Sources/Authsignal/Models/AppCredential.swift
+++ b/Sources/Authsignal/Models/AppCredential.swift
@@ -1,6 +1,35 @@
+import Foundation
+
 public struct AppCredential: Codable {
   public let credentialId: String
   public let createdAt: String
   public let userId: String
   public let lastAuthenticatedAt: String?
+  public let expiresAt: String?
+
+  public init(
+    credentialId: String,
+    createdAt: String,
+    userId: String,
+    lastAuthenticatedAt: String?,
+    expiresAt: String? = nil
+  ) {
+    self.credentialId = credentialId
+    self.createdAt = createdAt
+    self.userId = userId
+    self.lastAuthenticatedAt = lastAuthenticatedAt
+    self.expiresAt = expiresAt
+  }
+
+  /// Whether the credential's lease has lapsed, based on `expiresAt`.
+  /// Returns `false` when the server does not provide an expiry (no expiry configured).
+  public var isExpired: Bool {
+    guard let expiresAt = expiresAt,
+          let expiryDate = ISO8601DateFormatter().date(from: expiresAt)
+    else {
+      return false
+    }
+
+    return expiryDate < Date()
+  }
 }


### PR DESCRIPTION
## What's new

Adds support for push credential expiry and keep-alive.

- `updateCredential` now takes an optional `pushToken` and a new `resetExpiry` flag:

  ```swift
  // Rotate the push token (existing behaviour, unchanged)
  await authsignal.push.updateCredential(pushToken: token)

  // Keep-alive: reset the credential's expiry lease without changing the token
  await authsignal.push.updateCredential(resetExpiry: true)
  ```

- When `pushToken` is omitted, the server keeps the stored token.
- `AppCredential` now exposes `expiresAt` (ISO timestamp), so you can check when the credential's lease lapses and re-enroll in time. Expired credentials are rejected by the server and cannot be revived.
- The `updateCredential` response now includes the refreshed `expiresAt`.

## Compatibility

Fully backward compatible: existing `updateCredential(pushToken: "...")` calls compile and behave exactly as before.

Ships as 2.12.0.

