### PR TITLE
Add credential delivery error fields

### DIFF
--- a/Authsignal.podspec
+++ b/Authsignal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Authsignal'
-  s.version          = '2.13.0'
+  s.version          = '2.14.0'
   s.summary          = 'The Authsignal SDK for iOS'
 
   s.homepage         = 'https://github.com/authsignal/authsignal-ios'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check out our [official iOS documentation](https://docs.authsignal.com/sdks/clie
 Add Authsignal to your Podfile:
 
 ```rb
-pod 'Authsignal', '~> 2.13.0'
+pod 'Authsignal', '~> 2.14.0'
 ```
 
 #### Swift Package Manager
@@ -20,7 +20,7 @@ Add authsignal-ios to the dependencies value of your Package.swift.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/authsignal/authsignal-ios.git", from: "2.13.0")
+    .package(url: "https://github.com/authsignal/authsignal-ios.git", from: "2.14.0")
 ]
 ```
 

--- a/Sources/Authsignal/API/Models/App/CredentialResponse.swift
+++ b/Sources/Authsignal/API/Models/App/CredentialResponse.swift
@@ -4,4 +4,6 @@ public struct CredentialResponse: Codable {
   public let userId: String
   public let lastVerifiedAt: String?
   public let expiresAt: String?
+  public let erroredAt: String?
+  public let errorCode: String?
 }

--- a/Sources/Authsignal/API/Models/App/UpdateCredentialResponse.swift
+++ b/Sources/Authsignal/API/Models/App/UpdateCredentialResponse.swift
@@ -4,4 +4,6 @@ public struct UpdateCredentialResponse: Codable {
   public let lastVerifiedAt: String
   public let pushToken: String?
   public let expiresAt: String?
+  public let erroredAt: String?
+  public let errorCode: String?
 }

--- a/Sources/Authsignal/AuthsignalPush.swift
+++ b/Sources/Authsignal/AuthsignalPush.swift
@@ -31,7 +31,9 @@ public class AuthsignalPush {
       createdAt: data.verifiedAt,
       userId: data.userId,
       lastAuthenticatedAt: data.lastVerifiedAt,
-      expiresAt: data.expiresAt
+      expiresAt: data.expiresAt,
+      erroredAt: data.erroredAt,
+      errorCode: data.errorCode
     )
 
     return AuthsignalResponse(data: credential)

--- a/Sources/Authsignal/AuthsignalRequestMetadata.swift
+++ b/Sources/Authsignal/AuthsignalRequestMetadata.swift
@@ -9,7 +9,7 @@ struct AuthsignalWrapperSDKMetadata {
 
 @objc public class AuthsignalRequestMetadata: NSObject {
   private static let nativeSDK = "ios"
-  private static let nativeVersion = "2.13.0"
+  private static let nativeVersion = "2.14.0"
   private static let nativeUserAgentToken = "AuthsignalIOSSDK"
   private static var wrapperSDKMetadata: AuthsignalWrapperSDKMetadata?
 

--- a/Sources/Authsignal/Models/AppCredential.swift
+++ b/Sources/Authsignal/Models/AppCredential.swift
@@ -6,18 +6,24 @@ public struct AppCredential: Codable {
   public let userId: String
   public let lastAuthenticatedAt: String?
   public let expiresAt: String?
+  public let erroredAt: String?
+  public let errorCode: String?
 
   public init(
     credentialId: String,
     createdAt: String,
     userId: String,
     lastAuthenticatedAt: String?,
-    expiresAt: String? = nil
+    expiresAt: String? = nil,
+    erroredAt: String? = nil,
+    errorCode: String? = nil
   ) {
     self.credentialId = credentialId
     self.createdAt = createdAt
     self.userId = userId
     self.lastAuthenticatedAt = lastAuthenticatedAt
     self.expiresAt = expiresAt
+    self.erroredAt = erroredAt
+    self.errorCode = errorCode
   }
 }


### PR DESCRIPTION
When APNs reports that a device's push token is no longer valid, the credential's authenticator now records `erroredAt` and `errorCode` server-side. This exposes those fields on `AppCredential`, so an app can check `getCredential()` on launch and re-register its push token via `updateCredential` when the credential has a delivery error.

## Changes

- Adds optional `erroredAt` and `errorCode` to `AppCredential`, `CredentialResponse`, and `UpdateCredentialResponse`.
- `errorCode` is the push provider's own code passed through as-is (e.g. `Unregistered`).
- Bumps version to 2.14.0.

Both fields are optional and decode as `nil` until the corresponding API change is live.